### PR TITLE
feat: Render dynamic directions between origin and nearby destination marker on click

### DIFF
--- a/components/Map.js
+++ b/components/Map.js
@@ -12,15 +12,16 @@ export default function Map() {
   const [selected, setSelected] = useState(null);
   const [restaurants, setRestaurants] = useState([]);
   const [response, setResponse] = useState(null);
+  const [startPlaceID, setStartPlaceID] = useState("");
+  const [endPlaceID, setEndPlaceID] = useState("");
 
   const directionsServiceOptions = useMemo(() => {
-    //TODO: make option variables dynamic
     return {
-      destination: "Montreal",
-      origin: "Toronto",
-      travelMode: "DRIVING",
+      origin: { placeId: startPlaceID },
+      destination: { placeId: endPlaceID },
+      travelMode: "WALKING",
     };
-  }, []);
+  }, [startPlaceID, endPlaceID]);
 
   const directionsCallback = useCallback((result) => {
     setResponse(result);
@@ -39,6 +40,7 @@ export default function Map() {
         <PlacesAutocomplete
           setSelected={setSelected}
           setRestaurants={setRestaurants}
+          setStartPlaceID={setStartPlaceID}
         />
       </div>
       <GoogleMap
@@ -59,7 +61,9 @@ export default function Map() {
             }}
           />
         )}
-        {restaurants && <Nearby restaurants={restaurants} />}
+        {restaurants && (
+          <Nearby restaurants={restaurants} setEndPlaceID={setEndPlaceID} />
+        )}
         <DirectionsService
           options={directionsServiceOptions}
           callback={directionsCallback}

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -11,9 +11,9 @@ export default function Navbar() {
       <nav>
         {navLinks.map((link, index) => {
           return (
-            <ul>
+            <ul key={index}>
               <Link href={link.path}>
-                <li key={index}>{link.name}</li>
+                <li>{link.name}</li>
               </Link>
             </ul>
           );

--- a/components/Nearby.js
+++ b/components/Nearby.js
@@ -1,11 +1,15 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { MarkerF } from "@react-google-maps/api";
 
-export default function Nearby({ restaurants }) {
+export default function Nearby({ restaurants, setEndPlaceID }) {
   return (
     <>
       {restaurants.map((restaurant) => (
-        <MarkerF position={restaurant.geometry.location} />
+        <MarkerF
+          position={restaurant.geometry.location}
+          key={restaurant.place_id}
+          onClick={() => setEndPlaceID(restaurant.place_id)}
+        />
       ))}
     </>
   );

--- a/components/PlacesAutocomplete.js
+++ b/components/PlacesAutocomplete.js
@@ -7,7 +7,7 @@ import { OverlayTrigger, Popover, ListGroup } from "react-bootstrap";
 export default function PlacesAutocomplete({
   setSelected,
   setRestaurants,
-  setRoutes,
+  setStartPlaceID,
 }) {
   const {
     ready,
@@ -24,6 +24,7 @@ export default function PlacesAutocomplete({
     const results = await getGeocode({ address });
     const { lat, lng } = await getLatLng(results[0]);
     setSelected({ lat, lng });
+    setStartPlaceID(results[0].place_id);
     //TODO: Create nearby results interface
     const response = await fetch(`api/google?lat=${lat}&lng=${lng}`);
     const restaurants = await response.json();


### PR DESCRIPTION
In `directionsServiceOptions`, `origin` is set by the user through the search bar, and `destination` is set by the user by clicking on one of the nearby markers.