### PR TITLE
Implement different map views based on `inExplore` mode

### DIFF
--- a/components/Map.js
+++ b/components/Map.js
@@ -14,6 +14,7 @@ export default function Map() {
     directionsResponse,
     setDirectionsResponse,
     savedPicks,
+    inExploreView,
   } = useContext(AppContext);
 
   const directionsServiceOptions = useMemo(() => {
@@ -52,14 +53,14 @@ export default function Map() {
         center={searchedLocationCoordinates}
         mapContainerClassName="map-container"
       >
-        <Markers />
-        {savedPicks.length > 1 && (
+        {inExploreView && <Markers />}
+        {!inExploreView && savedPicks.length > 1 && (
           <DirectionsService
             options={directionsServiceOptions}
             callback={directionsCallback}
           />
         )}
-        {directionsResponse && (
+        {!inExploreView && directionsResponse && (
           <DirectionsRenderer options={directionsResult} />
         )}
       </GoogleMap>


### PR DESCRIPTION
- Render all markers, searched and nearby picks, while `inExplore` mode
- Render markers and directions for saved picks only when not `inExplore` mode.