### PR TITLE
Optimize Explore Component with SWRImmutable and Context Updates

### DIFF
--- a/components/Markers/Nearby.js
+++ b/components/Markers/Nearby.js
@@ -3,21 +3,15 @@ import { MarkerF } from "@react-google-maps/api";
 import { AppContext } from "../../contexts/AppContext";
 
 export default function Nearby() {
-  const { nearbyPicks, setUserSelectedPick } =
-    useContext(AppContext);
+  const { nearbyPicks, setUserSelectedPickID } = useContext(AppContext);
   return (
     <>
       {nearbyPicks.map((pick) => (
         <MarkerF
           position={pick.geometry?.location}
           key={pick.place_id}
-          onClick={async () => {
-            const searchedPlaceDetailsResponse = await fetch(
-              `api/googlePlaceDetails?placeID=${pick.place_id}`
-            );
-            const searchedPlaceDetails =
-              await searchedPlaceDetailsResponse.json();
-            setUserSelectedPick(searchedPlaceDetails.result);
+          onClick={() => {
+            setUserSelectedPickID(pick.place_id);
           }}
         />
       ))}

--- a/components/Markers/Searched.js
+++ b/components/Markers/Searched.js
@@ -3,20 +3,15 @@ import { MarkerF } from "@react-google-maps/api";
 import { AppContext } from "../../contexts/AppContext";
 
 export default function Searched() {
-  const { searchedPlaces, setUserSelectedPick } = useContext(AppContext);
+  const { searchedPlaces, setUserSelectedPickID } = useContext(AppContext);
   return (
     <>
       {searchedPlaces.map((pick) => (
         <MarkerF
           position={pick.geometry?.location}
           key={pick.place_id}
-          onClick={async () => {
-            const searchedPlaceDetailsResponse = await fetch(
-              `api/googlePlaceDetails?placeID=${pick.place_id}`
-            );
-            const searchedPlaceDetails =
-              await searchedPlaceDetailsResponse.json();
-            setUserSelectedPick(searchedPlaceDetails.result);
+          onClick={() => {
+            setUserSelectedPickID(pick.place_id);
           }}
           icon={{
             path: "M8 12l-4.7023 2.4721.898-5.236L.3916 5.5279l5.2574-.764L8 0l2.3511 4.764 5.2574.7639-3.8043 3.7082.898 5.236z",

--- a/components/PlacesAutocomplete.js
+++ b/components/PlacesAutocomplete.js
@@ -16,6 +16,7 @@ export default function PlacesAutocomplete() {
     setSearchedPlaceID,
     setSearchedPlaces,
     searchedPlaces,
+    setUserSelectedPickID,
   } = useContext(AppContext);
 
   const {
@@ -34,6 +35,7 @@ export default function PlacesAutocomplete() {
     const { lat, lng } = await getLatLng(results[0]);
     setSearchedLocationCoordinates({ lat, lng });
     setSearchedPlaceID(placeID);
+    setUserSelectedPickID(placeID);
     //TODO: add a test for city validity
     const city = terms.at(-3).value;
     setSearchedCity(city);

--- a/components/PlacesAutocomplete.js
+++ b/components/PlacesAutocomplete.js
@@ -13,7 +13,6 @@ export default function PlacesAutocomplete() {
     setNearbyPicks,
     setSearchedCity,
     setUserSelectedPick,
-    setSearchedPlaceID,
     setSearchedPlaces,
     searchedPlaces,
     setUserSelectedPickID,
@@ -34,7 +33,6 @@ export default function PlacesAutocomplete() {
     const results = await getGeocode({ address });
     const { lat, lng } = await getLatLng(results[0]);
     setSearchedLocationCoordinates({ lat, lng });
-    setSearchedPlaceID(placeID);
     setUserSelectedPickID(placeID);
     //TODO: add a test for city validity
     const city = terms.at(-3).value;

--- a/components/Sidebar/explore.js
+++ b/components/Sidebar/explore.js
@@ -1,4 +1,5 @@
-import { useContext, useCallback, useMemo } from "react";
+import useSWRImmutable from "swr/immutable";
+import { useContext, useCallback, useMemo, useEffect } from "react";
 import { AppContext } from "../../contexts/AppContext";
 import {
   Button,
@@ -14,11 +15,26 @@ import {
 export default function Explore() {
   const {
     userSelectedPick,
+    setUserSelectedPick,
+    userSelectedPickID,
     savedPicks,
     setSavedPicks,
     inExploreView,
     setInExploreView,
   } = useContext(AppContext);
+
+  const fetcher = (...args) => fetch(...args).then((res) => res.json());
+
+  const { data: selectedPickDetails } = useSWRImmutable(
+    `api/googlePlaceDetails?placeID=${userSelectedPickID}`,
+    fetcher
+  );
+
+  useEffect(() => {
+    if (selectedPickDetails) {
+      setUserSelectedPick(selectedPickDetails.result);
+    }
+  }, [selectedPickDetails, setUserSelectedPick]);
 
   const toggleSaveCallback = useCallback(() => {
     if (saveButtonText === "save pick") {
@@ -70,7 +86,6 @@ export default function Explore() {
         >
           toggle explore/saved view
         </Button>
-
         <UnorderedList>
           <ListItem>{`Ratings & Reviews: ${userSelectedPick?.rating} stars, ${userSelectedPick?.user_ratings_total} reviews`}</ListItem>
           <ListItem>

--- a/contexts/AppContext.js
+++ b/contexts/AppContext.js
@@ -9,6 +9,7 @@ export default function AppContextProvider({ children }) {
     useState(null);
   const [searchedCity, setSearchedCity] = useState("");
   const [userSelectedPick, setUserSelectedPick] = useState({});
+  const [userSelectedPickID, setUserSelectedPickID] = useState("");
   const [nearbyPicks, setNearbyPicks] = useState([]);
   const [savedPicks, setSavedPicks] = useState([]);
   const [directionsResponse, setDirectionsResponse] = useState(null);
@@ -26,6 +27,8 @@ export default function AppContextProvider({ children }) {
         setSearchedCity,
         userSelectedPick,
         setUserSelectedPick,
+        userSelectedPickID,
+        setUserSelectedPickID,
         nearbyPicks,
         setNearbyPicks,
         savedPicks,

--- a/contexts/AppContext.js
+++ b/contexts/AppContext.js
@@ -3,7 +3,7 @@ import React, { createContext, useState } from "react";
 export const AppContext = createContext();
 
 export default function AppContextProvider({ children }) {
-  const [searchedPlaceID, setSearchedPlaceID] = useState("");
+
   const [searchedPlaces, setSearchedPlaces] = useState([]);
   const [searchedLocationCoordinates, setSearchedLocationCoordinates] =
     useState(null);
@@ -17,8 +17,6 @@ export default function AppContextProvider({ children }) {
   return (
     <AppContext.Provider
       value={{
-        searchedPlaceID,
-        setSearchedPlaceID,
         searchedPlaces,
         setSearchedPlaces,
         searchedLocationCoordinates,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next": "^13.4.13",
         "react": "^18.2.0",
         "react-bootstrap": "^2.8.0",
+        "swr": "^2.2.2",
         "use-places-autocomplete": "^4.0.0"
       },
       "devDependencies": {
@@ -5345,6 +5346,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.2.tgz",
+      "integrity": "sha512-CbR41AoMD4TQBQw9ic3GTXspgfM9Y8Mdhb5Ob4uIKXhWqnRLItwA5fpGvB7SmSw3+zEjb0PdhiEumtUvYoQ+bQ==",
+      "dependencies": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -5607,6 +5620,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/warning": {
@@ -9667,6 +9688,15 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
+    "swr": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.2.tgz",
+      "integrity": "sha512-CbR41AoMD4TQBQw9ic3GTXspgfM9Y8Mdhb5Ob4uIKXhWqnRLItwA5fpGvB7SmSw3+zEjb0PdhiEumtUvYoQ+bQ==",
+      "requires": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
     "tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -9850,6 +9880,12 @@
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "warning": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "next": "^13.4.13",
     "react": "^18.2.0",
     "react-bootstrap": "^2.8.0",
+    "swr": "^2.2.2",
     "use-places-autocomplete": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**Context**
The Explore component is a crucial part of the Pick's application, responsible for providing users with detailed information about their selected picks.

**Changes Made**
-Created the `userSelectedPickID` context, which is set when clicking on map markers or selecting a place through the search bar.
-Removed the `searchedPlaceID` context, as it duplicates the functionality of `userSelectedPickID` and is now redundant.
-Implemented SWRImmutable caching in the Explore Component, preventing automatic revalidations. This aligns with the app's requirements, as we want to avoid unnecessary revalidation of place details information.