### PR TITLE
Fix Dropdown List Item Click in PlacesAutocomplete

### DIFF
--- a/components/PlacesAutocomplete.js
+++ b/components/PlacesAutocomplete.js
@@ -78,12 +78,14 @@ export default function PlacesAutocomplete() {
           width="100%"
         >
           {data.map(({ place_id, description, terms }) => (
-            <ListItem
-              key={place_id}
-              onClick={() => handleSelect(place_id, description, terms)}
-            >
-              <Link href="/picks">{description}</Link>
-            </ListItem>
+            <Link href="/picks" key={place_id}>
+              <ListItem
+                key={place_id}
+                onClick={() => handleSelect(place_id, description, terms)}
+              >
+                {description}
+              </ListItem>
+            </Link>
           ))}
         </List>
       )}


### PR DESCRIPTION
**Details**
This PR addresses a bug related to the behavior of clicking on addresses in the dropdown list of the PlacesAutocomplete component. The issue sometimes prevents proper navigation to the '/picks' page when clicking on an address.

**Changes Made**
Moved the <Link> component to wrap the <ListItem> elements within the dropdown list. This adjustment ensures that clicking on any part of the list item will trigger navigation to the '/picks' page.

**Test**
The following test in `searchbar.spec.js` now passes with the changes made:
```js
test("should navigate to 'Picks' page after selecting an address from the dropdown list", async ({
  page,
}) => {
  await page.goto("/");
  const searchbar = await page.waitForSelector(
    'input[placeholder="type in location..."]'
  );
  await searchbar.type("Smile House Cafe");
  await page.locator('li:has-text("Smile House Cafe")').click();
  await expect(page).toHaveURL("/picks");
});
```