### PR TITLE
Resolve Nested Anchor Elements Issue in Searchbar Dropdown

### DIFF
--- a/components/PlacesAutocomplete.js
+++ b/components/PlacesAutocomplete.js
@@ -97,17 +97,15 @@ export default function PlacesAutocomplete() {
           width="100%"
         >
           {data.map(({ place_id, description, terms }) => (
-            <NextLink href="/picks" key={place_id} passHref>
-              <Link>
-                <ListItem
-                  key={place_id}
-                  onClick={() => handleSelect(place_id, description, terms)}
-                  _hover={{ background: "gray.200" }}
-                >
-                  {description}
-                </ListItem>
-              </Link>
-            </NextLink>
+            <Link as={NextLink} href="/picks" key={place_id}>
+              <ListItem
+                key={place_id}
+                onClick={() => handleSelect(place_id, description, terms)}
+                _hover={{ background: "gray.200" }}
+              >
+                {description}
+              </ListItem>
+            </Link>
           ))}
         </List>
       )}


### PR DESCRIPTION
- Removed the NextLink component that wraps the Chakra UI Link component
- Refactored the Chakra UI Link component to use the 'as' property, setting it to use the NextLink component as its anchor element