### PR TITLE
Feature: Customizable "Saved Picks" Order

### DIFF
--- a/components/Sidebar/Saved.js
+++ b/components/Sidebar/Saved.js
@@ -28,6 +28,22 @@ export default function Saved() {
             h="248px"
             direction={{ base: "column", sm: "row" }}
             position="relative"
+            draggable="true"
+            onDragStart={(ev) => {
+              ev.dataTransfer.setData("text/plain", JSON.stringify(pick));
+            }}
+            onDragOver={(ev) => ev.preventDefault()}
+            onDrop={(ev) => {
+              ev.preventDefault();
+              const placeData = ev.dataTransfer.getData("text/plain");
+              const draggedPlace = JSON.parse(placeData);
+              const draggedIndex = savedPicks.findIndex(
+                (place) => place.place_id === draggedPlace.place_id
+              );
+              const updatedPicks = savedPicks.toSpliced(draggedIndex, 1);
+              updatedPicks.splice(index, 0, draggedPlace);
+              setSavedPicks(updatedPicks);
+            }}
           >
             {" "}
             <Image

--- a/components/Sidebar/Saved.js
+++ b/components/Sidebar/Saved.js
@@ -23,6 +23,7 @@ export default function Saved() {
         {savedPicks.map((pick, index) => (
           <Card
             key={pick.place_id}
+            id={pick.place_id}
             variant="filled"
             w="100%"
             h="248px"
@@ -37,12 +38,14 @@ export default function Saved() {
               ev.preventDefault();
               const placeData = ev.dataTransfer.getData("text/plain");
               const draggedPlace = JSON.parse(placeData);
-              const draggedIndex = savedPicks.findIndex(
-                (place) => place.place_id === draggedPlace.place_id
-              );
-              const updatedPicks = savedPicks.toSpliced(draggedIndex, 1);
-              updatedPicks.splice(index, 0, draggedPlace);
-              setSavedPicks(updatedPicks);
+              if (draggedPlace.place_id !== ev.target.id) {
+                const draggedIndex = savedPicks.findIndex(
+                  (place) => place.place_id === draggedPlace.place_id
+                );
+                const updatedPicks = savedPicks.toSpliced(draggedIndex, 1);
+                updatedPicks.splice(index, 0, draggedPlace);
+                setSavedPicks(updatedPicks);
+              }
             }}
           >
             {" "}


### PR DESCRIPTION
This PR introduces drag-and-drop interactions to allow users to customize the order of their "Saved Picks" list. When users update the saved list order through drag and drop, the map marker route also gets updated accordingly.

### Key Changes:

- Implemented HTML Drag and Drop API to enable drag-and-drop interactions for each card in the "Saved Picks" List.
- Added place ID as a class ID for each card, enabling a conditional check to prevent updating the "Saved Picks" list when a card is dragged and dropped in the same location.

