### PR TITLE
Implement Auto-Select of First Dropdown Item in Search

### DIFF
--- a/components/PlacesAutocomplete.js
+++ b/components/PlacesAutocomplete.js
@@ -80,7 +80,7 @@ export default function PlacesAutocomplete() {
       const newIndex =
         (selectedSearchbarPlaceIndex - 1 + data.length) % data.length;
       setSelectedSearchbarPlaceIndex(newIndex);
-    } else if (e.key === "Enter" && selectedSearchbarPlaceIndex !== -1) {
+    } else if (e.key === "Enter") {
       const selectedPlace = data[selectedSearchbarPlaceIndex];
       handleSelect(
         selectedPlace.place_id,
@@ -103,7 +103,7 @@ export default function PlacesAutocomplete() {
           value={value}
           onChange={(e) => {
             setValue(e.target.value);
-            setSelectedSearchbarPlaceIndex(-1);
+            setSelectedSearchbarPlaceIndex(0);
           }}
           onFocus={(e) => setValue(e.target.value)}
           isDisabled={!ready}

--- a/contexts/AppContext.js
+++ b/contexts/AppContext.js
@@ -14,7 +14,7 @@ export default function AppContextProvider({ children }) {
   const [directionsResponse, setDirectionsResponse] = useState(null);
   const [inExploreView, setInExploreView] = useState(true);
   const [selectedSearchbarPlaceIndex, setSelectedSearchbarPlaceIndex] =
-    useState(-1);
+    useState(0);
   const [isMapReady, setIsMapReady] = useState(false);
   return (
     <AppContext.Provider


### PR DESCRIPTION
### Overview:
This PR enhances the search query experience by automatically selecting the first item in the dropdown menu, allowing users to simply press Enter after entering their query.

### Changes Made:
- Updated the default value of `selectedSearchbarPlaceIndex` from -1 to 0 to highlight the first item in the dropdown by default.
- Removed the conditional check for `selectedSearchbarPlaceIndex` not being equal to -1, as it is unnecessary with the changes made in this PR.
