### PR TITLE
Refactor: Separate Explore and Saved View Logic From Map

### DIFF
--- a/components/Map.js
+++ b/components/Map.js
@@ -1,49 +1,12 @@
-import React, { useCallback, useMemo, useContext } from "react";
+import { useContext } from "react";
 import { AppContext } from "../contexts/AppContext";
-import {
-  GoogleMap,
-  DirectionsService,
-  DirectionsRenderer,
-  OverlayViewF,
-  OverlayView,
-} from "@react-google-maps/api";
+import { GoogleMap } from "@react-google-maps/api";
 import PlacesAutocomplete from "./PlacesAutocomplete";
-import Markers from "./Markers/Markers";
-import { Flex, Box, Card, CardBody } from "@chakra-ui/react";
+import View from "./View/View";
+import { Flex, Box } from "@chakra-ui/react";
 
 export default function Map() {
-  const {
-    searchedLocationCoordinates,
-    directionsResponse,
-    setDirectionsResponse,
-    savedPicks,
-    inExploreView,
-  } = useContext(AppContext);
-
-  const directionsServiceOptions = useMemo(() => {
-    return {
-      origin: { placeId: savedPicks?.[0]?.place_id },
-      destination: { placeId: savedPicks?.at(-1)?.place_id },
-      waypoints: savedPicks.slice(1, -1).map((pick) => ({
-        stopover: true,
-        location: {
-          placeId: pick.place_id,
-        },
-      })),
-      optimizeWaypoints: true,
-      travelMode: "WALKING",
-    };
-  }, [savedPicks]);
-
-  const directionsCallback = useCallback((result) => {
-    setDirectionsResponse(result);
-  }, []);
-
-  const directionsResult = useMemo(() => {
-    return {
-      directions: directionsResponse,
-    };
-  }, [directionsResponse]);
+  const { searchedLocationCoordinates } = useContext(AppContext);
 
   return (
     <Flex direction={"column"}>
@@ -54,34 +17,7 @@ export default function Map() {
           center={searchedLocationCoordinates}
           mapContainerClassName="map-container"
         >
-          {inExploreView && <Markers />}
-          {!inExploreView && savedPicks.length > 1 && (
-            <DirectionsService
-              options={directionsServiceOptions}
-              callback={directionsCallback}
-            />
-          )}
-          {!inExploreView && directionsResponse && (
-            <DirectionsRenderer options={directionsResult} />
-          )}
-          {!inExploreView &&
-            directionsResponse?.routes?.[0]?.legs?.length &&
-            directionsResponse.routes[0].legs.map((leg, index) => (
-              <OverlayViewF
-                key={index}
-                position={
-                  leg.steps[Math.floor(leg.steps.length / 2)].start_location
-                }
-                mapPaneName={OverlayView.OVERLAY_LAYER}
-              >
-                <Card size="sm">
-                  <CardBody>
-                    <h1>{leg.distance.text}</h1>
-                    <h1>{leg.duration.text}</h1>
-                  </CardBody>
-                </Card>
-              </OverlayViewF>
-            ))}
+          <View />
         </GoogleMap>
       </Box>
     </Flex>

--- a/components/Markers/SavedMarker.js
+++ b/components/Markers/SavedMarker.js
@@ -1,0 +1,20 @@
+import { useContext } from "react";
+import { MarkerF } from "@react-google-maps/api";
+import { AppContext } from "../../contexts/AppContext";
+
+export default function SavedMarker() {
+  const { savedPicks } = useContext(AppContext);
+  return (
+    <>
+      {savedPicks?.map((pick) => (
+        <MarkerF
+          position={pick.geometry?.location}
+          key={pick.place_id}
+          onClick={() => {
+            setUserSelectedPickID(pick.place_id);
+          }}
+        />
+      ))} 
+    </>
+  );
+}

--- a/components/View/ExploreView.js
+++ b/components/View/ExploreView.js
@@ -1,0 +1,5 @@
+import Markers from "../Markers/Markers";
+
+export default function ExploreView() {
+  return <Markers />;
+}

--- a/components/View/SavedView.js
+++ b/components/View/SavedView.js
@@ -1,5 +1,6 @@
 import { useMemo, useCallback, useContext } from "react";
 import { AppContext } from "../../contexts/AppContext";
+import SavedMarker from "../Markers/SavedMarker";
 import {
   DirectionsService,
   DirectionsRenderer,
@@ -36,31 +37,35 @@ export default function SavedView() {
     };
   }, [directionsResponse]);
 
-  return (
-    <>
-      <DirectionsService
-        options={directionsServiceOptions}
-        callback={directionsCallback}
-      />
-      <DirectionsRenderer options={directionsResult} />
-      {directionsResponse?.routes?.[0]?.legs?.length
-        ? directionsResponse.routes[0].legs.map((leg, index) => (
-            <OverlayViewF
-              key={index}
-              position={
-                leg.steps[Math.floor(leg.steps.length / 2)].start_location
-              }
-              mapPaneName={OverlayView.OVERLAY_LAYER}
-            >
-              <Card size="sm">
-                <CardBody>
-                  <h1>{leg.distance.text}</h1>
-                  <h1>{leg.duration.text}</h1>
-                </CardBody>
-              </Card>
-            </OverlayViewF>
-          ))
-        : null}
-    </>
-  );
+  if (savedPicks.length > 1) {
+    return (
+      <>
+        <DirectionsService
+          options={directionsServiceOptions}
+          callback={directionsCallback}
+        />
+        <DirectionsRenderer options={directionsResult} />
+        {directionsResponse?.routes?.[0]?.legs?.length
+          ? directionsResponse.routes[0].legs.map((leg, index) => (
+              <OverlayViewF
+                key={index}
+                position={
+                  leg.steps[Math.floor(leg.steps.length / 2)].start_location
+                }
+                mapPaneName={OverlayView.OVERLAY_LAYER}
+              >
+                <Card size="sm">
+                  <CardBody>
+                    <h1>{leg.distance.text}</h1>
+                    <h1>{leg.duration.text}</h1>
+                  </CardBody>
+                </Card>
+              </OverlayViewF>
+            ))
+          : null}
+      </>
+    );
+  } else {
+    return <SavedMarker />;
+  }
 }

--- a/components/View/SavedView.js
+++ b/components/View/SavedView.js
@@ -1,0 +1,66 @@
+import { useMemo, useCallback, useContext } from "react";
+import { AppContext } from "../../contexts/AppContext";
+import {
+  DirectionsService,
+  DirectionsRenderer,
+  OverlayViewF,
+  OverlayView,
+} from "@react-google-maps/api";
+import { Card, CardBody } from "@chakra-ui/react";
+
+export default function SavedView() {
+  const { savedPicks, directionsResponse, setDirectionsResponse } =
+    useContext(AppContext);
+  const directionsServiceOptions = useMemo(() => {
+    return {
+      origin: { placeId: savedPicks?.[0]?.place_id },
+      destination: { placeId: savedPicks?.at(-1)?.place_id },
+      waypoints: savedPicks.slice(1, -1).map((pick) => ({
+        stopover: true,
+        location: {
+          placeId: pick.place_id,
+        },
+      })),
+      optimizeWaypoints: true,
+      travelMode: "WALKING",
+    };
+  }, [savedPicks]);
+
+  const directionsCallback = useCallback((result) => {
+    setDirectionsResponse(result);
+  }, []);
+
+  const directionsResult = useMemo(() => {
+    return {
+      directions: directionsResponse,
+    };
+  }, [directionsResponse]);
+
+  return (
+    <>
+      <DirectionsService
+        options={directionsServiceOptions}
+        callback={directionsCallback}
+      />
+      <DirectionsRenderer options={directionsResult} />
+      {directionsResponse?.routes?.[0]?.legs?.length
+        ? directionsResponse.routes[0].legs.map((leg, index) => (
+            <OverlayViewF
+              key={index}
+              position={
+                leg.steps[Math.floor(leg.steps.length / 2)].start_location
+              }
+              mapPaneName={OverlayView.OVERLAY_LAYER}
+            >
+              <Card size="sm">
+                <CardBody>
+                  <h1>{leg.distance.text}</h1>
+                  <h1>{leg.duration.text}</h1>
+                </CardBody>
+              </Card>
+            </OverlayViewF>
+          ))
+        : null}
+    </>
+  );
+}

--- a/components/View/View.js
+++ b/components/View/View.js
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { AppContext } from "../../contexts/AppContext";
+import ExploreView from "./ExploreView";
+import SavedView from "./SavedView";
+
+export default function View() {
+  const { inExploreView } = useContext(AppContext);
+
+  return inExploreView ? <ExploreView /> : <SavedView />;
+}


### PR DESCRIPTION
1. **Separation of Logic:**
   - Moved `inExploreView` logic from `Map.js` into a new `View` component.

2. **Conditional Rendering in View Component:**
   - The `View` component now dynamically displays either `ExploreView` or `SavedView` logic based on the `inExploreView` state.

3. **Reminder:**
   - `ExploreView`: Renders markers from user searches and top attractions near them.
   - `SavedView`: Renders markers from the `savedPicks` list.

4. **SavedMarker Component:**
   - Created a new `SavedMarker` component designed to render markers from the `savedPicks` list. This component is intended for use in the `SavedView` component.

5. **SavedView Refactoring:**
   - Refactored the `SavedView` component to:
     - Display directions when the `savedPicks` list length is greater than 1.
     - Render one or no markers using the `SavedMarker` component when the list is empty or has only one item.
